### PR TITLE
Fixed syntax errors in battery i3-block

### DIFF
--- a/scripts/i3blocks/battery.sh
+++ b/scripts/i3blocks/battery.sh
@@ -2,20 +2,16 @@
 batinf='acpi -b'
 perc=$(acpi -b | awk '{print $4;}' | sed 's/%//g' | sed 's/,//g')
 
-if [ $perc > '75' ]
+if (( $perc > '75' ))
 then echo "  $perc%"
-elif [ $perc > '50' ]
+elif (( $perc > '50' ))
 then echo "  $perc%"
-elif [ $perc > '25' ]
+elif (( $perc > '25' ))
 then echo "  $perc%"
-elif  $perc > '10' ]
+elif  (( $perc > '10' ))
 then echo "  $perc%"
 else
 echo "  $perc%"
 fi
-
-
-
-
 
 


### PR DESCRIPTION
I was greatly inspired by your dotfiles and post on reddit so I stole a few ideas for my i3 setup. One thing I found broken was this battery script so I fixed that and now just submitting the patch back upstream.
